### PR TITLE
added `_` to the `\w` set

### DIFF
--- a/lib/sets.js
+++ b/lib/sets.js
@@ -6,7 +6,8 @@ var INTS = function() {
 
 var WORDS = function() {
  return [
-      { type: types.RANGE, from: 97, to: 122 }
+      { type: types.CHAR, value: 95 }
+    , { type: types.RANGE, from: 97, to: 122 }
     , { type: types.RANGE, from: 65, to: 90 }
   ].concat(INTS());
 };


### PR DESCRIPTION
According to regex101.com:

```
\w match any word character [a-zA-Z0-9_]
```

I also think the carriage return should be added to the `.` token.
