### PR TITLE
Fix convert escaped chars in regex source

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -16,8 +16,13 @@ var SLSH = { '0': 0, 't': 9, 'n': 10, 'v': 11, 'f': 12, 'r': 13 };
  * @return {String}
  */
 exports.strToChars = function(str) {
-  var chars_regex = /(\[\\b\])|\\(?:u([A-F0-9]{4})|x([A-F0-9]{2})|(0?[0-7]{2})|c([@A-Z\[\\\]\^?])|([0tnvfr]))/g;
-  str = str.replace(chars_regex, function(s, b, a16, b16, c8, dctrl, eslsh) {
+  var chars_regex = /(\[\\b\])|(\\)?\\(?:u([A-F0-9]{4})|x([A-F0-9]{2})|(0?[0-7]{2})|c([@A-Z\[\\\]\^?])|([0tnvfr]))/g;
+  str = str.replace(chars_regex, function(s, b, lbs, a16, b16, c8, dctrl, eslsh) {
+    
+    if (lbs) {
+      return s;
+    }
+
     var code = b     ? 8 :
                a16   ? parseInt(a16, 16) :
                b16   ? parseInt(b16, 16) :

--- a/test/util-test.js
+++ b/test/util-test.js
@@ -17,7 +17,18 @@ vows.describe('strToChars')
         assert.equal(str,
           '\xFF hellow \u00A3 \\( there  \n \\w');
       }
-    }
+    },
+    'Escaped chars in regex source remain espaced': {
+      topic: function() {
+        return util.strToChars(
+          /\\xFF hellow \\u00A3 \\50 there \\cB \\n \\w/.source);
+      },
+
+      'Returned string has escaped characters': function(str) {
+        assert.equal(str,
+          '\\\\xFF hellow \\\\u00A3 \\\\50 there \\\\cB \\\\n \\\\w');
+      }
+    },
   })
   .export(module);
 


### PR DESCRIPTION
I faced a problem and it looks like I found an bug.

```javascript
ret = require('ret');

console.log(ret(/\t/.source));

// {
//     type: 0,
//     stack: [{
//         type: 7,
//         value: 9
//     }]
// }

console.log(ret(/\\t/.source));

// {
//     type: 0,
//     stack: [{
//         type: 7,
//         value: 9
//     }]
// }
```
For solve this problem I added check for lookbehind slash in utils module and test for that. What do you think about this?