### PR TITLE
#10: Handle whitespaces in characters class correctly

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -52,7 +52,7 @@ exports.strToChars = function(str) {
 exports.tokenizeClass = (str, regexpStr) => {
   /* jshint maxlen: false */
   var tokens = [];
-  var regexp = /\\(?:(w)|(d)|(s)|(W)|(D)|(S))|((?:(?:\\)(.)|([^\]\\]))-(?:\\)?([^\]]))|(\])|(?:\\)?(.|[\r\n])/g;
+  var regexp = /\\(?:(w)|(d)|(s)|(W)|(D)|(S))|((?:(?:\\)(.)|([^\]\\]))-(?:\\)?([^\]]))|(\])|(?:\\)?([^])/g;
   var rs, c;
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -52,7 +52,7 @@ exports.strToChars = function(str) {
 exports.tokenizeClass = (str, regexpStr) => {
   /* jshint maxlen: false */
   var tokens = [];
-  var regexp = /\\(?:(w)|(d)|(s)|(W)|(D)|(S))|((?:(?:\\)(.)|([^\]\\]))-(?:\\)?([^\]]))|(\])|(?:\\)?(.)/g;
+  var regexp = /\\(?:(w)|(d)|(s)|(W)|(D)|(S))|((?:(?:\\)(.)|([^\]\\]))-(?:\\)?([^\]]))|(\])|(?:\\)?(.|[\r\n])/g;
   var rs, c;
 
 

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -152,9 +152,12 @@ vows.describe('Regexp Tokenizer')
         });
       },
       'Whitespace characters': {
-        'topic': ret('[\t\r\n ]'),
+        'topic': ret('[\t\r\n\u2028\u2029 ]'),
 
         'Class contains some whitespace characters (not included in .)': (t) => {
+          const LINE_SEPARATOR = String.fromCharCode(8232) // \u2028
+          const PAGE_SEPARATOR = String.fromCharCode(8233) // \u2029
+
           assert.deepEqual(t, {
             type: types.ROOT,
             stack: [
@@ -164,6 +167,8 @@ vows.describe('Regexp Tokenizer')
                   char('\t'),
                   char('\r'),
                   char('\n'),
+                  char(LINE_SEPARATOR),
+                  char(PAGE_SEPARATOR),
                   char(' ')
                 ],
                 not: false,

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -150,6 +150,27 @@ vows.describe('Regexp Tokenizer')
             }
           ],
         });
+      },
+      'Whitespace characters': {
+        'topic': ret('[\t\r\n ]'),
+
+        'Class contains some whitespace characters (not included in .)': (t) => {
+          assert.deepEqual(t, {
+            type: types.ROOT,
+            stack: [
+              {
+                type: types.SET,
+                set: [
+                  char('\t'),
+                  char('\r'),
+                  char('\n'),
+                  char(' ')
+                ],
+                not: false,
+              },
+            ],
+          });
+        }
       }
     },
 


### PR DESCRIPTION
The problem is `.` in regexp matching single character, as it's not matching newlines correctly. It's commonly used (especially in expressions like `/(.|[\n])/` to catch all characters).

I added regression tests for this issue.