### PR TITLE
fix: fix parsing octal numbers for non-backreferences

### DIFF
--- a/lib/tokenizer.ts
+++ b/lib/tokenizer.ts
@@ -336,6 +336,7 @@ function updateReferences(referenceQueue: ReferenceQueue, groupCount: number) {
       elem.reference.type = types.CHAR;
 
       const valueString = elem.reference.value.toString();
+      elem.reference.value = parseInt(valueString, 8);
       // If the number is not octal then we need to create multiple tokens
       // https://github.com/fent/ret.js/pull/39#issuecomment-1008229226
       if (!/^[0-7]+$/.test(valueString)) {
@@ -353,7 +354,7 @@ function updateReferences(referenceQueue: ReferenceQueue, groupCount: number) {
           // If the escaped number does not start with 8 or 9, then all
           // 0-7 digits before the first 8/9 form the first character code
           // see: https://github.com/fent/ret.js/pull/39#discussion_r780747085
-          elem.reference.value = parseInt(valueString.slice(0, i), 10);
+          elem.reference.value = parseInt(valueString.slice(0, i), 8);
         }
 
         if (valueString.length > i) {

--- a/test/main-test.js
+++ b/test/main-test.js
@@ -486,7 +486,7 @@ vows.describe('Regexp Tokenizer')
               value: sets.words(),
             },
             char('<'),
-            { type: types.CHAR, value: 10 },
+            { type: types.CHAR, value: 8 },
             char('>'),
           ],
         });
@@ -542,7 +542,7 @@ vows.describe('Regexp Tokenizer')
                 char(' '),
                 char('-'),
                 char(' '),
-                { type: types.CHAR, value: 10 },
+                { type: types.CHAR, value: 8 },
               ],
           });
       },
@@ -710,7 +710,7 @@ vows.describe('Regexp Tokenizer')
         'Tokenizes correctly': t => {
           assert.deepStrictEqual(t, {
             type: types.ROOT, stack: [
-              { type: types.CHAR, value: 10 },
+              { type: types.CHAR, value: 8 },
             ],
           });
         },
@@ -731,7 +731,7 @@ vows.describe('Regexp Tokenizer')
         'Tokenizes correctly': t => {
           assert.deepStrictEqual(t, {
             type: types.ROOT, stack: [
-              { type: types.CHAR, value: 10 },
+              { type: types.CHAR, value: 8 },
               char('8'),
             ],
           });
@@ -742,7 +742,7 @@ vows.describe('Regexp Tokenizer')
         'Tokenizes correctly': t => {
           assert.deepStrictEqual(t, {
             type: types.ROOT, stack: [
-              { type: types.CHAR, value: 107 },
+              { type: types.CHAR, value: 71 },
             ],
           });
         },


### PR DESCRIPTION
I ran into this bug due to an automated update PR in another library that depends on this one

https://github.com/fent/randexp.js/runs/4917379232?check_suite_focus=true

if the escaped number is not a backreference, then it must be parsed as octal